### PR TITLE
feat: 구장 종류별 마감 임박 게시글 출력 기능 구현

### DIFF
--- a/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
+++ b/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.example.fieldpasserbe.post.controller;
 import com.example.fieldpasserbe.post.dto.PostRequestDto;
 import com.example.fieldpasserbe.post.dto.PostResponseDto;
 import com.example.fieldpasserbe.post.dto.WishPostRequest;
+import com.example.fieldpasserbe.post.entity.Post;
 import com.example.fieldpasserbe.post.service.PostSearchService;
 import com.example.fieldpasserbe.post.dto.PostListResponseDto;
 import com.example.fieldpasserbe.post.service.PostService;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -77,5 +80,10 @@ public class PostController {
     @PostMapping("/api/like/post")
     public String likePost(WishPostRequest wishPostRequest) {
         return wishPostService.likePost(wishPostRequest);
+    }
+
+    @GetMapping("/api/imminent")
+    public List<PostListResponseDto> findImminent(@RequestParam(name = "category") String category) {
+        return postSearchService.findImminent(category);
     }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/repository/PostRepositoryJPA.java
+++ b/src/main/java/com/example/fieldpasserbe/post/repository/PostRepositoryJPA.java
@@ -49,4 +49,5 @@ public interface PostRepositoryJPA extends JpaRepository<Post, Integer> {
                                                                                               PageRequest pageRequest);
 
     List<Post> findByStartTimeBefore(LocalDateTime dateTime);
+    List<Post> findTop20ByCategory_CategoryNameAndStartTimeAfterOrderByStartTimeAsc(String category, LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/PostSearchService.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/PostSearchService.java
@@ -4,6 +4,8 @@ import com.example.fieldpasserbe.post.dto.PostListResponseDto;
 import com.example.fieldpasserbe.post.dto.PostResponseDto;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 public interface PostSearchService {
 
     Long countPostById(int id);
@@ -21,5 +23,7 @@ public interface PostSearchService {
     Slice<PostListResponseDto> postListByCategoryAndDistrict(String category, String district, int page);
 
     Slice<PostListResponseDto> postListByCategoryAndDistrictAndStadium(String category, String district, String stadiumName, int page);
+
+    List<PostListResponseDto> findImminent(String category);
 
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/impl/PostSearchServiceImpl.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/impl/PostSearchServiceImpl.java
@@ -12,7 +12,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -73,5 +76,14 @@ public class PostSearchServiceImpl implements PostSearchService {
 
         return postRepository.findByCategory_CategoryNameAndDistrict_DistrictNameAndStadium_StadiumName(category, district, stadiumName, pageRequest)
                 .map(post -> new PostListResponseDto(post));
+    }
+
+    @Override
+    public List<PostListResponseDto> findImminent(String category) {
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        return postRepository.findTop20ByCategory_CategoryNameAndStartTimeAfterOrderByStartTimeAsc(category, nowDateTime)
+                .stream()
+                .map(post -> new PostListResponseDto(post))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작업한 대용에 대한 설명 
- 객체들의 연관관계를 기준으로 Entity를 설계했습니다.
- 도메인 별로 Repository를 생성했습니다.
-->

구장 종류별 마감 임박 게시글 출력 기능 구현하였습니다.

## Key Changes

<!-- 작업한 내용의 주요 변경 사항에 대한 나열
  - Post Entity 설계를 완료했습니다.
    - 기간은 Embedded 타입으로 설계했습니다.
  - 변경 2
  - 변경 3
-->

- 구장 종류 별로 요청 시간 기준으로 양도 시작 시간이 가까운 순으로 최대 20개 게시글 리스트 가져오는 기능 구현하였습니다.

## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->

변경사항이 적으니 빠른 코드 리뷰 후 머지 부탁드립니다!
또한 이 기능은 메인 페이지 기능이나 이것만 따로 빼기가 애매하여 post 도메인에 넣어놨습니다.