### PR TITLE
feat: 관심 글 조회 및 관심 구장 조회 구현

### DIFF
--- a/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
+++ b/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
@@ -87,4 +87,9 @@ public class PostController {
     public List<WishPostResponseDto> myLikePostList(@RequestParam(name = "memberId") int memberId) {
         return wishPostService.myLikePostList(memberId);
     }
+
+    @GetMapping("/api/post/stadium/{stadiumName}")
+    public List<PostListResponseDto> myLikeStadiums(@PathVariable String stadiumName) {
+        return postSearchService.findByStadiumName(stadiumName);
+    }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
+++ b/src/main/java/com/example/fieldpasserbe/post/controller/PostController.java
@@ -1,11 +1,7 @@
 package com.example.fieldpasserbe.post.controller;
 
-import com.example.fieldpasserbe.post.dto.PostRequestDto;
-import com.example.fieldpasserbe.post.dto.PostResponseDto;
-import com.example.fieldpasserbe.post.dto.WishPostRequest;
-import com.example.fieldpasserbe.post.entity.Post;
+import com.example.fieldpasserbe.post.dto.*;
 import com.example.fieldpasserbe.post.service.PostSearchService;
-import com.example.fieldpasserbe.post.dto.PostListResponseDto;
 import com.example.fieldpasserbe.post.service.PostService;
 import com.example.fieldpasserbe.post.service.WishPostService;
 import lombok.RequiredArgsConstructor;
@@ -78,12 +74,17 @@ public class PostController {
     }
 
     @PostMapping("/api/like/post")
-    public String likePost(WishPostRequest wishPostRequest) {
-        return wishPostService.likePost(wishPostRequest);
+    public String likePost(WishPostRequestDto wishPostRequestDto) {
+        return wishPostService.likePost(wishPostRequestDto);
     }
 
     @GetMapping("/api/imminent")
     public List<PostListResponseDto> findImminent(@RequestParam(name = "category") String category) {
         return postSearchService.findImminent(category);
+    }
+
+    @GetMapping("/api/myPage/like/post") //추후 세션으로 변경
+    public List<WishPostResponseDto> myLikePostList(@RequestParam(name = "memberId") int memberId) {
+        return wishPostService.myLikePostList(memberId);
     }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/controller/StadiumController.java
+++ b/src/main/java/com/example/fieldpasserbe/post/controller/StadiumController.java
@@ -1,7 +1,7 @@
 package com.example.fieldpasserbe.post.controller;
 
 import com.example.fieldpasserbe.post.dto.StadiumResponseDto;
-import com.example.fieldpasserbe.post.dto.WishFieldRequest;
+import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
 import com.example.fieldpasserbe.post.service.StadiumService;
 import com.example.fieldpasserbe.post.service.WishFieldService;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class StadiumController {
     }
 
     @PostMapping("/api/like/stadium")
-    public String likeStadium(WishFieldRequest wishFieldRequest) {
-        return wishFieldService.likeStadium(wishFieldRequest);
+    public String likeStadium(WishFieldRequestDto wishFieldRequestDto) {
+        return wishFieldService.likeStadium(wishFieldRequestDto);
     }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/controller/StadiumController.java
+++ b/src/main/java/com/example/fieldpasserbe/post/controller/StadiumController.java
@@ -2,6 +2,8 @@ package com.example.fieldpasserbe.post.controller;
 
 import com.example.fieldpasserbe.post.dto.StadiumResponseDto;
 import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
+import com.example.fieldpasserbe.post.dto.WishFieldResponseDto;
+import com.example.fieldpasserbe.post.dto.WishPostResponseDto;
 import com.example.fieldpasserbe.post.service.StadiumService;
 import com.example.fieldpasserbe.post.service.WishFieldService;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +30,10 @@ public class StadiumController {
     @PostMapping("/api/like/stadium")
     public String likeStadium(WishFieldRequestDto wishFieldRequestDto) {
         return wishFieldService.likeStadium(wishFieldRequestDto);
+    }
+
+    @GetMapping("/api/myPage/like/stadium") //추후 세션으로 변경
+    public List<WishFieldResponseDto> myLikePostList(@RequestParam(name = "memberId") int memberId) {
+        return wishFieldService.myLikeStadiums(memberId);
     }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/dto/WishFieldRequestDto.java
+++ b/src/main/java/com/example/fieldpasserbe/post/dto/WishFieldRequestDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-public class WishFieldRequest {
+public class WishFieldRequestDto {
     private int memberId;
     private int stadiumId;
 

--- a/src/main/java/com/example/fieldpasserbe/post/dto/WishFieldResponseDto.java
+++ b/src/main/java/com/example/fieldpasserbe/post/dto/WishFieldResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.fieldpasserbe.post.dto;
+
+import com.example.fieldpasserbe.post.entity.WishField;
+import com.example.fieldpasserbe.post.entity.WishPost;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class WishFieldResponseDto {
+    private int stadiumId;
+    private String stadiumName;
+
+    public WishFieldResponseDto(WishField wishField) {
+        this.stadiumId = wishField.getStadium().getStadiumId();
+        this.stadiumName = wishField.getStadium().getStadiumName();
+    }
+}

--- a/src/main/java/com/example/fieldpasserbe/post/dto/WishPostRequestDto.java
+++ b/src/main/java/com/example/fieldpasserbe/post/dto/WishPostRequestDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-public class WishPostRequest {
+public class WishPostRequestDto {
     private int memberId;
     private int postId;
 

--- a/src/main/java/com/example/fieldpasserbe/post/dto/WishPostResponseDto.java
+++ b/src/main/java/com/example/fieldpasserbe/post/dto/WishPostResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.fieldpasserbe.post.dto;
+
+import com.example.fieldpasserbe.post.entity.WishPost;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class WishPostResponseDto {
+    private int postId;
+    private String title;
+
+    public WishPostResponseDto(WishPost wishPost) {
+        this.postId = wishPost.getPost().getPostId();
+        this.title = wishPost.getPost().getTitle();
+    }
+}

--- a/src/main/java/com/example/fieldpasserbe/post/repository/PostRepositoryJPA.java
+++ b/src/main/java/com/example/fieldpasserbe/post/repository/PostRepositoryJPA.java
@@ -49,9 +49,12 @@ public interface PostRepositoryJPA extends JpaRepository<Post, Integer> {
                                                                                               String district,
                                                                                               String stadiumName,
                                                                                               PageRequest pageRequest);
-
+    @EntityGraph(attributePaths = {"member","category","district","stadium"})
     List<Post> findByStartTimeBefore(LocalDateTime dateTime);
+    @EntityGraph(attributePaths = {"member","category","district","stadium"})
     List<Post> findTop20ByCategory_CategoryNameAndStartTimeAfterOrderByStartTimeAsc(String category, LocalDateTime dateTime);
+    @EntityGraph(attributePaths = {"member","category","district","stadium"})
+    List<Post> findByStadium_StadiumNameOrderByRegisterDateDesc(String stadiumName);
 
     //@EntityGraph(attributePaths = {"member","category","district","stadium"})
     @Query(value = "SELECT p.post_id as postId," +

--- a/src/main/java/com/example/fieldpasserbe/post/repository/WishFieldRepository.java
+++ b/src/main/java/com/example/fieldpasserbe/post/repository/WishFieldRepository.java
@@ -1,7 +1,15 @@
 package com.example.fieldpasserbe.post.repository;
 
 import com.example.fieldpasserbe.post.entity.WishField;
+import com.example.fieldpasserbe.post.entity.WishPost;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface WishFieldRepository extends JpaRepository<WishField, WishField> {
+    @EntityGraph(attributePaths = {"member","stadium"})
+    List<WishField> findByMember_MemberId(int memberId);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/repository/WishPostRepository.java
+++ b/src/main/java/com/example/fieldpasserbe/post/repository/WishPostRepository.java
@@ -2,7 +2,15 @@ package com.example.fieldpasserbe.post.repository;
 
 import com.example.fieldpasserbe.post.dto.WishPostId;
 import com.example.fieldpasserbe.post.entity.WishPost;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface WishPostRepository extends JpaRepository<WishPost, WishPostId> {
+    @EntityGraph(attributePaths = {"member","post"})
+    @Query("select wp from WishPost wp where wp.member.memberId = :memberId AND wp.post.deleteCheck = 0 AND wp.post.blind = 0")
+    List<WishPost> findByMemberId(@Param("memberId") int memberId);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/PostSearchService.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/PostSearchService.java
@@ -30,4 +30,6 @@ public interface PostSearchService {
 
     Page<PostResponseDTO> findPostsById(int page, int memberId) throws NullPointerException;
 
+    List<PostListResponseDto> findByStadiumName(String stadiumName);
+
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/WishFieldService.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/WishFieldService.java
@@ -1,7 +1,7 @@
 package com.example.fieldpasserbe.post.service;
 
-import com.example.fieldpasserbe.post.dto.WishFieldRequest;
+import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
 
 public interface WishFieldService {
-    String likeStadium(WishFieldRequest wishFieldRequest);
+    String likeStadium(WishFieldRequestDto wishFieldRequestDto);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/WishFieldService.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/WishFieldService.java
@@ -1,7 +1,11 @@
 package com.example.fieldpasserbe.post.service;
 
 import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
+import com.example.fieldpasserbe.post.dto.WishFieldResponseDto;
+
+import java.util.List;
 
 public interface WishFieldService {
     String likeStadium(WishFieldRequestDto wishFieldRequestDto);
+    List<WishFieldResponseDto> myLikeStadiums(int memberId);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/WishPostService.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/WishPostService.java
@@ -1,7 +1,11 @@
 package com.example.fieldpasserbe.post.service;
 
-import com.example.fieldpasserbe.post.dto.WishPostRequest;
+import com.example.fieldpasserbe.post.dto.WishPostRequestDto;
+import com.example.fieldpasserbe.post.dto.WishPostResponseDto;
+
+import java.util.List;
 
 public interface WishPostService {
-    String likePost(WishPostRequest wishPostRequest);
+    String likePost(WishPostRequestDto wishPostRequestDto);
+    List<WishPostResponseDto> myLikePostList(int memberId);
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/impl/PostSearchServiceImpl.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/impl/PostSearchServiceImpl.java
@@ -98,4 +98,12 @@ public class PostSearchServiceImpl implements PostSearchService {
             return posts;
         }
     }
+
+    @Override
+    public List<PostListResponseDto> findByStadiumName(String stadiumName) {
+        return postRepository.findByStadium_StadiumNameOrderByRegisterDateDesc(stadiumName)
+                .stream()
+                .map(post -> new PostListResponseDto(post))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/impl/WishFieldServiceImpl.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/impl/WishFieldServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.fieldpasserbe.post.service.impl;
 
-import com.example.fieldpasserbe.post.dto.WishFieldRequest;
+import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
 import com.example.fieldpasserbe.post.repository.WishFieldRepository;
 import com.example.fieldpasserbe.post.service.WishFieldService;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +13,9 @@ public class WishFieldServiceImpl implements WishFieldService {
     private final WishFieldRepository wishFieldRepository;
 
     @Override
-    public String likeStadium(WishFieldRequest wishFieldRequest) {
+    public String likeStadium(WishFieldRequestDto wishFieldRequestDto) {
         try {
-            wishFieldRepository.save(wishFieldRequest.toEntity());
+            wishFieldRepository.save(wishFieldRequestDto.toEntity());
         } catch (Exception e) {
             return "failed";
         }

--- a/src/main/java/com/example/fieldpasserbe/post/service/impl/WishFieldServiceImpl.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/impl/WishFieldServiceImpl.java
@@ -1,10 +1,14 @@
 package com.example.fieldpasserbe.post.service.impl;
 
 import com.example.fieldpasserbe.post.dto.WishFieldRequestDto;
+import com.example.fieldpasserbe.post.dto.WishFieldResponseDto;
 import com.example.fieldpasserbe.post.repository.WishFieldRepository;
 import com.example.fieldpasserbe.post.service.WishFieldService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -21,5 +25,13 @@ public class WishFieldServiceImpl implements WishFieldService {
         }
 
         return "success";
+    }
+
+    @Override
+    public List<WishFieldResponseDto> myLikeStadiums(int memberId) {
+        return wishFieldRepository.findByMember_MemberId(memberId)
+                .stream()
+                .map(wishField -> new WishFieldResponseDto(wishField))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/fieldpasserbe/post/service/impl/WishPostServiceImpl.java
+++ b/src/main/java/com/example/fieldpasserbe/post/service/impl/WishPostServiceImpl.java
@@ -1,12 +1,16 @@
 package com.example.fieldpasserbe.post.service.impl;
 
-import com.example.fieldpasserbe.post.dto.WishPostRequest;
+import com.example.fieldpasserbe.post.dto.WishPostRequestDto;
+import com.example.fieldpasserbe.post.dto.WishPostResponseDto;
 import com.example.fieldpasserbe.post.repository.PostRepositoryJPA;
 import com.example.fieldpasserbe.post.repository.WishPostRepository;
 import com.example.fieldpasserbe.post.service.WishPostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -17,15 +21,23 @@ public class WishPostServiceImpl implements WishPostService {
 
     @Transactional
     @Override
-    public String likePost(WishPostRequest wishPostRequest) {
+    public String likePost(WishPostRequestDto wishPostRequestDto) {
         try {
-            int postId = wishPostRequest.getPostId();
+            int postId = wishPostRequestDto.getPostId();
             postRepositoryJPA.updateWishCount(postId);
-            wishPostRepository.save(wishPostRequest.toEntity());
+            wishPostRepository.save(wishPostRequestDto.toEntity());
         } catch (Exception e) {
             return "failed";
         }
 
         return "success";
+    }
+
+    @Override
+    public List<WishPostResponseDto> myLikePostList(int memberId) {
+        return wishPostRepository.findByMemberId(memberId)
+                .stream()
+                .map(wishPost -> new WishPostResponseDto(wishPost))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작업한 대용에 대한 설명 
- 객체들의 연관관계를 기준으로 Entity를 설계했습니다.
- 도메인 별로 Repository를 생성했습니다.
-->
    
관심 글, 관심 구장 조회와 관련된 기능 개발하였습니다.

## Key Changes

<!-- 작업한 내용의 주요 변경 사항에 대한 나열
  - Post Entity 설계를 완료했습니다.
    - 기간은 Embedded 타입으로 설계했습니다.
  - 변경 2
  - 변경 3
-->

- 마이페이지에서 관심 글 조회 기능 개발 (memberId 통해 postId랑 제목만 가져옴)
- 마이페이지에서 관심 구장 조회 기능 개발  (memberId 통해 stadiumId랑 구장명만 가져옴)
- 관심 구장 조회 후 구장명 클릭하면 이동할 수 있도록 구장명만으로 게시글 조회하는 API 추가

## To reviewers

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->

머지 충돌나서 다시한번 잘 확인해줘용